### PR TITLE
test: add comprehensive test suite for core modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_version.py
 .vscode/
 temp.dot
 layout.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Dear RosNodeViewer is a Python GUI tool for visualizing ROS 2 node diagrams. It supports three input sources:
+- CARET architecture YAML files (performance analysis framework)
+- rosgraph.dot files (from rqt_graph)
+- Live ROS 2 runtime graph analysis
+
+## Build and Development Commands
+
+### System Dependencies (Ubuntu/Debian)
+```bash
+sudo apt install -y graphviz graphviz-dev
+```
+
+### Installation
+```bash
+pip install -e .                    # Development install
+pip install -r requirements.txt     # Install dev dependencies
+```
+
+### Running the Application
+```bash
+dear_ros_node_viewer <graph_file>   # Load YAML or DOT file
+dear_ros_node_viewer ros            # Live ROS 2 analysis
+dear_ros_node_viewer --save-only <file>  # Batch mode without GUI
+```
+
+## Testing
+
+```bash
+# Run all tests with coverage
+pytest --doctest-modules -v --cov=./src/dear_ros_node_viewer
+
+# Run single test file
+pytest tests/test_caret2networkx.py -v
+
+# Run single test class
+pytest tests/test_caret2networkx.py::TestQuoteName -v
+
+# Run single test method
+pytest tests/test_caret2networkx.py::TestQuoteName::test_quote_name_basic -v
+
+# Run tests with short traceback
+pytest tests/ -v --tb=short
+```
+
+### Test Files
+| File | Tests |
+|------|-------|
+| `test_caret2networkx.py` | CARET YAML parsing |
+| `test_dot2networkx.py` | DOT file parsing |
+| `test_graph_layout.py` | Node positioning (requires graphviz) |
+| `test_graph_manager.py` | Graph loading/filtering (requires graphviz) |
+| `test_logger_factory.py` | Logging configuration |
+| `test_caret_extend_callback_group.py` | Callback group extraction |
+| `test_caret_extend_path.py` | Path extraction |
+
+Note: Some tests require `graphviz` to be installed and will be skipped if not available.
+
+## Linting
+
+```bash
+# Flake8 - critical errors only
+flake8 . --exclude=.venv --count --select=E9,F63,F7,F82 --show-source --statistics
+
+# Flake8 - full check
+flake8 . --exclude=.venv --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+# Pylint
+pylint ./src/dear_ros_node_viewer --disable=E0401,W1203,C0301
+```
+
+## Architecture
+
+The codebase follows MVVM-style architecture:
+
+```
+src/dear_ros_node_viewer/
+├── dear_ros_node_viewer.py  # CLI entry point, settings management
+├── graph_view.py            # GUI layer (Dear PyGui rendering)
+├── graph_viewmodel.py       # State management, coordinates view/manager
+├── graph_manager.py         # Graph loading, filtering, NetworkX operations
+├── graph_layout.py          # Node positioning algorithms
+├── caret2networkx.py        # CARET YAML → NetworkX converter
+├── dot2networkx.py          # DOT file → NetworkX converter
+├── ros2networkx.py          # Live ROS 2 → NetworkX (requires rclpy)
+└── logger_factory.py        # Centralized logging configuration
+```
+
+### Data Flow
+1. Input parsers (`caret2networkx`, `dot2networkx`, `ros2networkx`) convert sources to NetworkX MultiDiGraph
+2. `graph_manager` loads graphs, applies filtering, manages graph state
+3. `graph_layout` positions nodes based on group settings
+4. `graph_viewmodel` coordinates between manager and view
+5. `graph_view` renders using Dear PyGui
+
+### Key Patterns
+- ROS dependencies (rclpy, rqt_graph) are optional and wrapped in try-except
+- Uses NetworkX MultiDiGraph to handle multiple edges between nodes
+- Group-based layout with horizontal/vertical direction support
+- Configuration via `setting.json` for GUI settings and node ignore patterns
+
+## Code Style
+- 2-space indentation (configured in `.pylintrc`)
+- Max line length: 127 characters
+- Google-style docstrings
+- Apache License 2.0 header on all Python files

--- a/README.md
+++ b/README.md
@@ -46,6 +46,35 @@ dear_ros_node_viewer architecture_autoware.yaml
 [See WiKi](https://github.com/iwatake2222/dear_ros_node_viewer/wiki/01.-How-to-Use)
 
 
+## Development
+
+### Setup
+```sh
+git clone https://github.com/iwatake2222/dear_ros_node_viewer.git
+cd dear_ros_node_viewer
+pip install -e .
+pip install -r requirements.txt
+```
+
+### Running Tests
+```sh
+# Run all tests
+pytest tests/ -v
+
+# Run with coverage
+pytest --doctest-modules -v --cov=./src/dear_ros_node_viewer
+
+# Run single test file
+pytest tests/test_caret2networkx.py -v
+```
+
+### Linting
+```sh
+flake8 . --exclude=.venv --count --select=E9,F63,F7,F82 --show-source --statistics
+pylint ./src/dear_ros_node_viewer --disable=E0401,W1203,C0301
+```
+
+
 # Acknowledgements
 - Dear RosNodeViewer utilizes [Dear PyGui](https://github.com/hoffstadt/DearPyGui)
   - *Dear RosNodeViewer* is named in honor of Dear PyGui

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,8 @@ version_file = "src/dear_ros_node_viewer/_version.py"
 # version_scheme= "no-guess-dev"
 local_scheme = "no-local-version"
 fallback_version = "0.0.0"
+
+[tool.flake8]
+exclude = [".venv", "build", "dist", "*.egg-info"]
+max-line-length = 127
+max-complexity = 10

--- a/tests/test_caret2networkx.py
+++ b/tests/test_caret2networkx.py
@@ -14,19 +14,283 @@
 """
 Test caret2networkx module
 """
+import os
+import tempfile
+import pytest
+import networkx as nx
 
-from src.dear_ros_node_viewer.caret2networkx import caret2networkx, quote_name
+from src.dear_ros_node_viewer.caret2networkx import (
+    caret2networkx,
+    quote_name,
+    parse_all_graph,
+    parse_target_path,
+    make_graph_from_topic_association,
+)
 
 
-def test_quote_name():
-    name = 'abc'
-    new_name = quote_name(name)
-    assert new_name == '"abc"'
+class TestQuoteName:
+    """Tests for quote_name function"""
+
+    def test_quote_name_basic(self):
+        """Test basic name quoting"""
+        assert quote_name('abc') == '"abc"'
+
+    def test_quote_name_with_slash(self):
+        """Test name quoting with slash (ROS node name format)"""
+        assert quote_name('/node_name') == '"/node_name"'
+
+    def test_quote_name_empty(self):
+        """Test empty string quoting"""
+        assert quote_name('') == '""'
+
+    def test_quote_name_special_chars(self):
+        """Test name with special characters"""
+        assert quote_name('/ns/node_123') == '"/ns/node_123"'
 
 
-def test_caret2networkx():
-    graph = caret2networkx('architecture.yaml')
-    assert(graph.has_node('"/node_src"'))
+class TestParseAllGraph:
+    """Tests for parse_all_graph function"""
 
-    graph = caret2networkx('architecture.yaml', target_path='target_path_0')
-    assert(graph.has_node('"/node_src"'))
+    def test_parse_all_graph_basic(self):
+        """Test parsing all graph from YAML structure"""
+        yml = {
+            'nodes': [
+                {
+                    'node_name': '/node_a',
+                    'publishes': [{'topic_name': '/topic_1'}],
+                    'subscribes': [{'topic_name': '/topic_2'}]
+                },
+                {
+                    'node_name': '/node_b',
+                    'publishes': [{'topic_name': '/topic_2'}],
+                }
+            ]
+        }
+        node_name_list = []
+        topic_pub_dict = {}
+        topic_sub_dict = {}
+
+        parse_all_graph(yml, node_name_list, topic_pub_dict, topic_sub_dict)
+
+        assert '"/node_a"' in node_name_list
+        assert '"/node_b"' in node_name_list
+        assert '/topic_1' in topic_pub_dict
+        assert '/topic_2' in topic_sub_dict
+        assert '"/node_a"' in topic_pub_dict['/topic_1']
+
+    def test_parse_all_graph_no_publishes(self):
+        """Test parsing node without publishes"""
+        yml = {
+            'nodes': [
+                {
+                    'node_name': '/node_a',
+                    'subscribes': [{'topic_name': '/topic_1'}]
+                }
+            ]
+        }
+        node_name_list = []
+        topic_pub_dict = {}
+        topic_sub_dict = {}
+
+        parse_all_graph(yml, node_name_list, topic_pub_dict, topic_sub_dict)
+
+        assert '"/node_a"' in node_name_list
+        assert len(topic_pub_dict) == 0
+        assert '/topic_1' in topic_sub_dict
+
+    def test_parse_all_graph_no_subscribes(self):
+        """Test parsing node without subscribes"""
+        yml = {
+            'nodes': [
+                {
+                    'node_name': '/node_a',
+                    'publishes': [{'topic_name': '/topic_1'}]
+                }
+            ]
+        }
+        node_name_list = []
+        topic_pub_dict = {}
+        topic_sub_dict = {}
+
+        parse_all_graph(yml, node_name_list, topic_pub_dict, topic_sub_dict)
+
+        assert '"/node_a"' in node_name_list
+        assert '/topic_1' in topic_pub_dict
+        assert len(topic_sub_dict) == 0
+
+    def test_parse_all_graph_multiple_publishers(self):
+        """Test multiple nodes publishing to same topic"""
+        yml = {
+            'nodes': [
+                {
+                    'node_name': '/node_a',
+                    'publishes': [{'topic_name': '/topic_1'}],
+                },
+                {
+                    'node_name': '/node_b',
+                    'publishes': [{'topic_name': '/topic_1'}],
+                }
+            ]
+        }
+        node_name_list = []
+        topic_pub_dict = {}
+        topic_sub_dict = {}
+
+        parse_all_graph(yml, node_name_list, topic_pub_dict, topic_sub_dict)
+
+        assert len(topic_pub_dict['/topic_1']) == 2
+        assert '"/node_a"' in topic_pub_dict['/topic_1']
+        assert '"/node_b"' in topic_pub_dict['/topic_1']
+
+
+class TestParseTargetPath:
+    """Tests for parse_target_path function"""
+
+    def test_parse_target_path_basic(self):
+        """Test parsing target path from YAML structure"""
+        yml = {
+            'named_paths': [
+                {
+                    'path_name': 'path_0',
+                    'node_chain': [
+                        {
+                            'node_name': '/node_a',
+                            'publish_topic_name': '/topic_1',
+                            'subscribe_topic_name': 'UNDEFINED'
+                        },
+                        {
+                            'node_name': '/node_b',
+                            'publish_topic_name': 'UNDEFINED',
+                            'subscribe_topic_name': '/topic_1'
+                        }
+                    ]
+                }
+            ]
+        }
+        node_name_list = []
+        topic_pub_dict = {}
+        topic_sub_dict = {}
+
+        parse_target_path(yml, node_name_list, topic_pub_dict, topic_sub_dict)
+
+        assert '"/node_a"' in node_name_list
+        assert '"/node_b"' in node_name_list
+        assert '/topic_1' in topic_pub_dict
+        assert '/topic_1' in topic_sub_dict
+
+    def test_parse_target_path_empty(self):
+        """Test parsing empty named_paths"""
+        yml = {'named_paths': []}
+        node_name_list = []
+        topic_pub_dict = {}
+        topic_sub_dict = {}
+
+        parse_target_path(yml, node_name_list, topic_pub_dict, topic_sub_dict)
+
+        assert len(node_name_list) == 0
+
+
+class TestMakeGraphFromTopicAssociation:
+    """Tests for make_graph_from_topic_association function"""
+
+    def test_make_graph_basic(self):
+        """Test creating graph from topic associations"""
+        topic_pub_dict = {'/topic_1': ['"/node_a"']}
+        topic_sub_dict = {'/topic_1': ['"/node_b"']}
+
+        graph = make_graph_from_topic_association(topic_pub_dict, topic_sub_dict)
+
+        assert graph.has_node('"/node_a"')
+        assert graph.has_node('"/node_b"')
+        assert graph.has_edge('"/node_a"', '"/node_b"')
+
+    def test_make_graph_no_subscriber(self):
+        """Test graph creation when topic has no subscriber"""
+        topic_pub_dict = {'/topic_1': ['"/node_a"']}
+        topic_sub_dict = {}
+
+        graph = make_graph_from_topic_association(topic_pub_dict, topic_sub_dict)
+
+        # Node should not be added if there's no subscriber
+        assert not graph.has_node('"/node_a"')
+
+    def test_make_graph_multiple_connections(self):
+        """Test graph with multiple publishers and subscribers"""
+        topic_pub_dict = {'/topic_1': ['"/node_a"', '"/node_b"']}
+        topic_sub_dict = {'/topic_1': ['"/node_c"', '"/node_d"']}
+
+        graph = make_graph_from_topic_association(topic_pub_dict, topic_sub_dict)
+
+        # Each publisher should connect to each subscriber
+        assert graph.has_edge('"/node_a"', '"/node_c"')
+        assert graph.has_edge('"/node_a"', '"/node_d"')
+        assert graph.has_edge('"/node_b"', '"/node_c"')
+        assert graph.has_edge('"/node_b"', '"/node_d"')
+
+    def test_make_graph_edge_label(self):
+        """Test that edges have correct topic labels"""
+        topic_pub_dict = {'/topic_1': ['"/node_a"']}
+        topic_sub_dict = {'/topic_1': ['"/node_b"']}
+
+        graph = make_graph_from_topic_association(topic_pub_dict, topic_sub_dict)
+
+        edge_data = graph.get_edge_data('"/node_a"', '"/node_b"')
+        assert edge_data is not None
+        assert edge_data[0]['label'] == '/topic_1'
+
+
+class TestCaret2Networkx:
+    """Tests for caret2networkx function"""
+
+    def test_caret2networkx_all_graph(self):
+        """Test loading architecture.yaml with all_graph mode"""
+        graph = caret2networkx('architecture.yaml')
+        assert graph.has_node('"/node_src"')
+        assert graph.has_node('"/node_dst"')
+        assert isinstance(graph, nx.MultiDiGraph)
+
+    def test_caret2networkx_target_path(self):
+        """Test loading architecture.yaml with target_path mode"""
+        graph = caret2networkx('architecture.yaml', target_path='target_path_0')
+        assert graph.has_node('"/node_src"')
+        assert graph.has_node('"/node_dst"')
+
+    def test_caret2networkx_display_unconnected(self):
+        """Test loading with display_unconnected_nodes option"""
+        graph = caret2networkx('architecture.yaml', display_unconnected_nodes=True)
+        # All nodes should be present even if unconnected
+        assert len(graph.nodes) >= 1
+
+    def test_caret2networkx_file_not_found(self):
+        """Test error handling for non-existent file"""
+        with pytest.raises(FileNotFoundError):
+            caret2networkx('nonexistent_file.yaml')
+
+    def test_caret2networkx_invalid_yaml(self):
+        """Test error handling for invalid YAML file"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write('invalid: yaml: content: [')
+            temp_path = f.name
+
+        try:
+            with pytest.raises(Exception):
+                caret2networkx(temp_path)
+        finally:
+            os.unlink(temp_path)
+
+    def test_caret2networkx_empty_nodes(self):
+        """Test handling YAML with empty nodes list"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write('nodes: []\n')
+            temp_path = f.name
+
+        try:
+            graph = caret2networkx(temp_path)
+            assert len(graph.nodes) == 0
+        finally:
+            os.unlink(temp_path)
+
+    def test_caret2networkx_returns_multidigraph(self):
+        """Test that function returns MultiDiGraph (allows multiple edges)"""
+        graph = caret2networkx('architecture.yaml')
+        assert isinstance(graph, nx.MultiDiGraph)

--- a/tests/test_caret_extend_callback_group.py
+++ b/tests/test_caret_extend_callback_group.py
@@ -1,0 +1,341 @@
+# Copyright 2023 iwatake2222
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test caret_extend_callback_group module
+"""
+import networkx as nx
+
+from src.dear_ros_node_viewer.caret_extend_callback_group import (
+    create_dict_cbgroup2executor,
+    create_callback_detail,
+    create_callback_group_list,
+    create_dict_node_callbackgroup,
+    extend_callback_group,
+)
+
+
+class TestCreateDictCbgroup2Executor:
+    """Tests for create_dict_cbgroup2executor function"""
+
+    def test_basic(self):
+        """Test basic executor mapping"""
+        yml = {
+            'executors': [
+                {
+                    'executor_name': 'executor_0',
+                    'executor_type': 'multi_threaded_executor',
+                    'callback_group_names': ['/node_a/callback_group_0']
+                }
+            ]
+        }
+
+        dict_cbgroup2executor, dict_cbgroup2color = create_dict_cbgroup2executor(yml)
+
+        assert '/node_a/callback_group_0' in dict_cbgroup2executor
+        assert 'executor_0' in dict_cbgroup2executor['/node_a/callback_group_0']
+        assert '/node_a/callback_group_0' in dict_cbgroup2color
+
+    def test_multiple_callback_groups(self):
+        """Test executor with multiple callback groups"""
+        yml = {
+            'executors': [
+                {
+                    'executor_name': 'executor_0',
+                    'executor_type': 'multi_threaded_executor',
+                    'callback_group_names': [
+                        '/node_a/callback_group_0',
+                        '/node_b/callback_group_0'
+                    ]
+                }
+            ]
+        }
+
+        dict_cbgroup2executor, dict_cbgroup2color = create_dict_cbgroup2executor(yml)
+
+        assert '/node_a/callback_group_0' in dict_cbgroup2executor
+        assert '/node_b/callback_group_0' in dict_cbgroup2executor
+        # Multiple callback groups should have non-white color
+        color = dict_cbgroup2color['/node_a/callback_group_0']
+        assert len(color) == 3
+
+    def test_single_callback_group_white_color(self):
+        """Test that single callback group gets white color"""
+        yml = {
+            'executors': [
+                {
+                    'executor_name': 'executor_0',
+                    'executor_type': 'single_threaded_executor',
+                    'callback_group_names': ['/node_a/callback_group_0']
+                }
+            ]
+        }
+
+        _, dict_cbgroup2color = create_dict_cbgroup2executor(yml)
+
+        assert dict_cbgroup2color['/node_a/callback_group_0'] == [255, 255, 255]
+
+    def test_multiple_executors(self):
+        """Test multiple executors"""
+        yml = {
+            'executors': [
+                {
+                    'executor_name': 'executor_0',
+                    'executor_type': 'multi_threaded_executor',
+                    'callback_group_names': ['/node_a/callback_group_0']
+                },
+                {
+                    'executor_name': 'executor_1',
+                    'executor_type': 'single_threaded_executor',
+                    'callback_group_names': ['/node_b/callback_group_0']
+                }
+            ]
+        }
+
+        dict_cbgroup2executor, _ = create_dict_cbgroup2executor(yml)
+
+        assert 'executor_0' in dict_cbgroup2executor['/node_a/callback_group_0']
+        assert 'executor_1' in dict_cbgroup2executor['/node_b/callback_group_0']
+
+
+class TestCreateCallbackDetail:
+    """Tests for create_callback_detail function"""
+
+    def test_subscription_callback(self):
+        """Test creating detail for subscription callback"""
+        callbacks = [
+            {
+                'callback_name': '/node_a/callback_0',
+                'callback_type': 'subscription_callback',
+                'topic_name': '/topic_1'
+            }
+        ]
+
+        result = create_callback_detail(callbacks, '/node_a/callback_0')
+
+        assert result is not None
+        assert result['callback_name'] == '/node_a/callback_0'
+        assert result['callback_type'] == 'sub'
+        assert result['description'] == '/topic_1'
+
+    def test_timer_callback(self):
+        """Test creating detail for timer callback"""
+        callbacks = [
+            {
+                'callback_name': '/node_a/callback_0',
+                'callback_type': 'timer_callback',
+                'period_ns': 20000000  # 20ms
+            }
+        ]
+
+        result = create_callback_detail(callbacks, '/node_a/callback_0')
+
+        assert result is not None
+        assert result['callback_type'] == 'timer'
+        assert '20.0ms' in result['description']
+
+    def test_callback_not_found(self):
+        """Test handling of non-existent callback"""
+        callbacks = [
+            {
+                'callback_name': '/node_a/callback_0',
+                'callback_type': 'subscription_callback',
+                'topic_name': '/topic_1'
+            }
+        ]
+
+        result = create_callback_detail(callbacks, '/nonexistent/callback')
+
+        assert result is None
+
+    def test_unknown_callback_type(self):
+        """Test handling of unknown callback type"""
+        callbacks = [
+            {
+                'callback_name': '/node_a/callback_0',
+                'callback_type': 'unknown_callback_type',
+            }
+        ]
+
+        result = create_callback_detail(callbacks, '/node_a/callback_0')
+
+        assert result is not None
+        assert result['callback_type'] == 'unknown_callback_type'
+
+
+class TestCreateCallbackGroupList:
+    """Tests for create_callback_group_list function"""
+
+    def test_basic(self):
+        """Test creating callback group list"""
+        node = {
+            'node_name': '/node_a',
+            'callback_groups': [
+                {
+                    'callback_group_name': '/node_a/callback_group_0',
+                    'callback_group_type': 'mutually_exclusive',
+                    'callback_names': ['/node_a/callback_0']
+                }
+            ],
+            'callbacks': [
+                {
+                    'callback_name': '/node_a/callback_0',
+                    'callback_type': 'subscription_callback',
+                    'topic_name': '/topic_1'
+                }
+            ]
+        }
+        dict_cbgroup2executor = {'/node_a/callback_group_0': 'executor_0, multi_'}
+        dict_cbgroup2color = {'/node_a/callback_group_0': [255, 255, 255]}
+
+        result = create_callback_group_list(node, dict_cbgroup2executor, dict_cbgroup2color)
+
+        assert len(result) == 1
+        assert result[0]['callback_group_name'] == '/node_a/callback_group_0'
+        assert len(result[0]['callback_detail_list']) == 1
+
+    def test_no_callback_groups(self):
+        """Test node without callback_groups"""
+        node = {
+            'node_name': '/node_a',
+        }
+        dict_cbgroup2executor = {}
+        dict_cbgroup2color = {}
+
+        result = create_callback_group_list(node, dict_cbgroup2executor, dict_cbgroup2color)
+
+        assert result == []
+
+    def test_no_callbacks(self):
+        """Test node without callbacks"""
+        node = {
+            'node_name': '/node_a',
+            'callback_groups': [
+                {
+                    'callback_group_name': '/node_a/callback_group_0',
+                    'callback_group_type': 'mutually_exclusive',
+                    'callback_names': []
+                }
+            ]
+        }
+        dict_cbgroup2executor = {}
+        dict_cbgroup2color = {}
+
+        result = create_callback_group_list(node, dict_cbgroup2executor, dict_cbgroup2color)
+
+        assert result == []
+
+    def test_callback_group_not_in_executor(self):
+        """Test callback group not registered with any executor"""
+        node = {
+            'node_name': '/node_a',
+            'callback_groups': [
+                {
+                    'callback_group_name': '/node_a/callback_group_0',
+                    'callback_group_type': 'mutually_exclusive',
+                    'callback_names': ['/node_a/callback_0']
+                }
+            ],
+            'callbacks': [
+                {
+                    'callback_name': '/node_a/callback_0',
+                    'callback_type': 'subscription_callback',
+                    'topic_name': '/topic_1'
+                }
+            ]
+        }
+        dict_cbgroup2executor = {}  # No executor mapping
+        dict_cbgroup2color = {}
+
+        result = create_callback_group_list(node, dict_cbgroup2executor, dict_cbgroup2color)
+
+        # Should skip callback groups not in executor
+        assert result == []
+
+
+class TestCreateDictNodeCallbackgroup:
+    """Tests for create_dict_node_callbackgroup function"""
+
+    def test_basic(self):
+        """Test creating node to callback group dictionary"""
+        yml = {
+            'executors': [
+                {
+                    'executor_name': 'executor_0',
+                    'executor_type': 'multi_threaded_executor',
+                    'callback_group_names': ['/node_a/callback_group_0']
+                }
+            ],
+            'nodes': [
+                {
+                    'node_name': '/node_a',
+                    'callback_groups': [
+                        {
+                            'callback_group_name': '/node_a/callback_group_0',
+                            'callback_group_type': 'mutually_exclusive',
+                            'callback_names': ['/node_a/callback_0']
+                        }
+                    ],
+                    'callbacks': [
+                        {
+                            'callback_name': '/node_a/callback_0',
+                            'callback_type': 'subscription_callback',
+                            'topic_name': '/topic_1'
+                        }
+                    ]
+                }
+            ]
+        }
+
+        result = create_dict_node_callbackgroup(yml)
+
+        assert '"/node_a"' in result
+        assert len(result['"/node_a"']) == 1
+
+
+class TestExtendCallbackGroup:
+    """Tests for extend_callback_group function"""
+
+    def test_extend_callback_group_basic(self):
+        """Test extending graph with callback group info"""
+        graph = nx.MultiDiGraph()
+        graph.add_node('"/node_src"')
+        graph.add_node('"/node_dst"')
+
+        result = extend_callback_group('architecture.yaml', graph)
+
+        # All nodes should have callback_group_list attribute
+        for node in result.nodes:
+            assert 'callback_group_list' in result.nodes[node]
+
+    def test_extend_callback_group_preserves_nodes(self):
+        """Test that extending preserves existing nodes"""
+        graph = nx.MultiDiGraph()
+        graph.add_node('"/node_src"')
+        graph.add_node('"/node_dst"')
+        graph.add_edge('"/node_src"', '"/node_dst"')
+
+        result = extend_callback_group('architecture.yaml', graph)
+
+        assert result.has_node('"/node_src"')
+        assert result.has_node('"/node_dst"')
+        assert result.has_edge('"/node_src"', '"/node_dst"')
+
+    def test_extend_callback_group_returns_graph(self):
+        """Test that function returns a graph"""
+        graph = nx.MultiDiGraph()
+        graph.add_node('"/node_src"')
+
+        result = extend_callback_group('architecture.yaml', graph)
+
+        assert isinstance(result, nx.MultiDiGraph)

--- a/tests/test_caret_extend_path.py
+++ b/tests/test_caret_extend_path.py
@@ -1,0 +1,139 @@
+# Copyright 2023 iwatake2222
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test caret_extend_path module
+"""
+import os
+import tempfile
+import pytest
+
+from src.dear_ros_node_viewer.caret_extend_path import get_path_dict
+
+
+class TestGetPathDict:
+    """Tests for get_path_dict function"""
+
+    def test_get_path_dict_basic(self):
+        """Test basic path dictionary extraction"""
+        path_dict = get_path_dict('architecture.yaml')
+
+        assert isinstance(path_dict, dict)
+        assert len(path_dict) > 0
+
+    def test_get_path_dict_has_target_paths(self):
+        """Test that path dictionary contains expected paths"""
+        path_dict = get_path_dict('architecture.yaml')
+
+        # architecture.yaml has target_path_0, target_path_1, target_path_2
+        assert 'target_path_0' in path_dict
+        assert 'target_path_1' in path_dict
+        assert 'target_path_2' in path_dict
+
+    def test_get_path_dict_node_list(self):
+        """Test that path contains node list"""
+        path_dict = get_path_dict('architecture.yaml')
+
+        # Each path should have a list of nodes
+        for path_name, node_list in path_dict.items():
+            assert isinstance(node_list, list)
+            assert len(node_list) > 0
+
+    def test_get_path_dict_quoted_node_names(self):
+        """Test that node names are properly quoted"""
+        path_dict = get_path_dict('architecture.yaml')
+
+        for path_name, node_list in path_dict.items():
+            for node_name in node_list:
+                # Node names should be quoted
+                assert node_name.startswith('"')
+                assert node_name.endswith('"')
+
+    def test_get_path_dict_target_path_0_nodes(self):
+        """Test specific nodes in target_path_0"""
+        path_dict = get_path_dict('architecture.yaml')
+
+        node_list = path_dict['target_path_0']
+        # target_path_0 should contain: /node_src, /node_src_0, /node_sub3pub1, /node_dst
+        assert '"/node_src"' in node_list
+        assert '"/node_dst"' in node_list
+
+    def test_get_path_dict_file_not_found(self):
+        """Test error handling for non-existent file"""
+        with pytest.raises(FileNotFoundError):
+            get_path_dict('nonexistent_file.yaml')
+
+    def test_get_path_dict_empty_named_paths(self):
+        """Test handling of empty named_paths"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write('named_paths: []\n')
+            temp_path = f.name
+
+        try:
+            path_dict = get_path_dict(temp_path)
+            assert path_dict == {}
+        finally:
+            os.unlink(temp_path)
+
+    def test_get_path_dict_single_path(self):
+        """Test handling of single path"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write('''named_paths:
+- path_name: single_path
+  node_chain:
+  - node_name: /node_a
+    publish_topic_name: /topic_1
+    subscribe_topic_name: UNDEFINED
+  - node_name: /node_b
+    publish_topic_name: UNDEFINED
+    subscribe_topic_name: /topic_1
+''')
+            temp_path = f.name
+
+        try:
+            path_dict = get_path_dict(temp_path)
+            assert 'single_path' in path_dict
+            assert len(path_dict['single_path']) == 2
+            assert '"/node_a"' in path_dict['single_path']
+            assert '"/node_b"' in path_dict['single_path']
+        finally:
+            os.unlink(temp_path)
+
+    def test_get_path_dict_preserves_order(self):
+        """Test that node order is preserved in path"""
+        path_dict = get_path_dict('architecture.yaml')
+
+        # target_path_0: /node_src -> /node_src_0 -> /node_sub3pub1 -> /node_dst
+        node_list = path_dict['target_path_0']
+        src_idx = node_list.index('"/node_src"')
+        dst_idx = node_list.index('"/node_dst"')
+
+        # /node_src should come before /node_dst
+        assert src_idx < dst_idx
+
+    def test_get_path_dict_multiple_paths_independent(self):
+        """Test that multiple paths are independent"""
+        path_dict = get_path_dict('architecture.yaml')
+
+        path_0 = path_dict['target_path_0']
+        path_1 = path_dict['target_path_1']
+
+        # Both paths should have /node_src and /node_dst but different intermediate nodes
+        assert '"/node_src"' in path_0
+        assert '"/node_src"' in path_1
+        assert '"/node_dst"' in path_0
+        assert '"/node_dst"' in path_1
+
+        # path_0 has /node_src_0, path_1 has /node_src_1
+        assert '"/node_src_0"' in path_0
+        assert '"/node_src_1"' in path_1

--- a/tests/test_dot2networkx.py
+++ b/tests/test_dot2networkx.py
@@ -14,13 +14,194 @@
 """
 Test dot2networkx module
 """
+import os
+import tempfile
+import pytest
+import networkx as nx
 
-from src.dear_ros_node_viewer.dot2networkx import dot2networkx
+from src.dear_ros_node_viewer.dot2networkx import (
+    dot2networkx,
+    dot2networkx_nodeonly,
+    dot2networkx_nodetopic,
+)
 
 
-def test_dot2networkx():
-    graph = dot2networkx('./sample/rosgraph_nodeonly.dot')
-    assert(graph.has_node('"/node_src"'))
+class TestDot2NetworkxNodeonly:
+    """Tests for dot2networkx_nodeonly function"""
 
-    graph = dot2networkx('./sample/rosgraph_nodetopic.dot')
-    assert(graph.has_node('"/node_src"'))
+    def test_nodeonly_basic(self):
+        """Test basic node-only DOT parsing"""
+        graph = dot2networkx('./sample/rosgraph_nodeonly.dot')
+        assert graph.has_node('"/node_src"')
+        assert graph.has_node('"/node_dst"')
+        assert isinstance(graph, nx.MultiDiGraph)
+
+    def test_nodeonly_edges(self):
+        """Test that edges are correctly parsed"""
+        graph = dot2networkx('./sample/rosgraph_nodeonly.dot')
+        # Check that there are edges in the graph
+        assert len(graph.edges) > 0
+
+    def test_nodeonly_display_unconnected(self):
+        """Test display_unconnected_nodes parameter"""
+        graph = dot2networkx('./sample/rosgraph_nodeonly.dot', display_unconnected_nodes=True)
+        assert len(graph.nodes) >= 1
+
+
+class TestDot2NetworkxNodetopic:
+    """Tests for dot2networkx_nodetopic function"""
+
+    def test_nodetopic_basic(self):
+        """Test basic node-topic DOT parsing"""
+        graph = dot2networkx('./sample/rosgraph_nodetopic.dot')
+        assert graph.has_node('"/node_src"')
+        assert graph.has_node('"/node_dst"')
+
+    def test_nodetopic_edges(self):
+        """Test that edges are correctly parsed from node-topic format"""
+        graph = dot2networkx('./sample/rosgraph_nodetopic.dot')
+        # Check that there are edges in the graph
+        assert len(graph.edges) > 0
+
+
+class TestDot2Networkx:
+    """Tests for main dot2networkx function"""
+
+    def test_dot2networkx_nodeonly(self):
+        """Test loading node-only DOT file"""
+        graph = dot2networkx('./sample/rosgraph_nodeonly.dot')
+        assert graph.has_node('"/node_src"')
+
+    def test_dot2networkx_nodetopic(self):
+        """Test loading node-topic DOT file"""
+        graph = dot2networkx('./sample/rosgraph_nodetopic.dot')
+        assert graph.has_node('"/node_src"')
+
+    def test_dot2networkx_file_not_found(self):
+        """Test error handling for non-existent file"""
+        with pytest.raises(Exception):
+            dot2networkx('nonexistent_file.dot')
+
+    def test_dot2networkx_invalid_dot(self):
+        """Test error handling for invalid DOT file"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dot', delete=False) as f:
+            f.write('invalid dot { content }}}')
+            temp_path = f.name
+
+        try:
+            with pytest.raises(Exception):
+                dot2networkx(temp_path)
+        finally:
+            os.unlink(temp_path)
+
+    def test_dot2networkx_empty_graph(self):
+        """Test handling empty DOT graph"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dot', delete=False) as f:
+            f.write('digraph G { }')
+            temp_path = f.name
+
+        try:
+            graph = dot2networkx(temp_path)
+            assert len(graph.nodes) == 0
+        finally:
+            os.unlink(temp_path)
+
+    def test_dot2networkx_returns_multidigraph(self):
+        """Test that function returns MultiDiGraph"""
+        graph = dot2networkx('./sample/rosgraph_nodeonly.dot')
+        assert isinstance(graph, nx.MultiDiGraph)
+
+    def test_dot2networkx_simple_graph(self):
+        """Test parsing a simple DOT graph"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dot', delete=False) as f:
+            f.write('''digraph G {
+                n1 [label="/node_a", shape=ellipse];
+                n2 [label="/node_b", shape=ellipse];
+                n1 -> n2 [label="/topic_1"];
+            }''')
+            temp_path = f.name
+
+        try:
+            graph = dot2networkx(temp_path)
+            assert graph.has_node('"/node_a"')
+            assert graph.has_node('"/node_b"')
+        finally:
+            os.unlink(temp_path)
+
+    def test_dot2networkx_with_box_shape(self):
+        """Test parsing DOT graph with box shapes (topics)"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dot', delete=False) as f:
+            f.write('''digraph G {
+                n1 [label="/node_a", shape=ellipse];
+                t1 [label="/topic_1", shape=box];
+                n2 [label="/node_b", shape=ellipse];
+                n1 -> t1;
+                t1 -> n2;
+            }''')
+            temp_path = f.name
+
+        try:
+            graph = dot2networkx(temp_path)
+            # Should have node_a and node_b connected through topic
+            assert graph.has_node('"/node_a"')
+            assert graph.has_node('"/node_b"')
+        finally:
+            os.unlink(temp_path)
+
+
+class TestDot2NetworkxNodeonlyInternal:
+    """Tests for internal dot2networkx_nodeonly function"""
+
+    def test_nodeonly_missing_label(self):
+        """Test handling nodes without label attribute"""
+        graph_org = nx.MultiDiGraph()
+        graph_org.add_node('n1')  # No label attribute
+        graph_org.add_node('n2', label='"/node_b"')
+
+        graph = dot2networkx_nodeonly(graph_org)
+
+        # Node without label should be skipped
+        assert not graph.has_node('n1')
+
+    def test_nodeonly_edge_missing_label(self):
+        """Test handling edges without label attribute"""
+        graph_org = nx.MultiDiGraph()
+        graph_org.add_node('n1', label='"/node_a"')
+        graph_org.add_node('n2', label='"/node_b"')
+        graph_org.add_edge('n1', 'n2')  # No label attribute
+
+        graph = dot2networkx_nodeonly(graph_org)
+
+        # Edge without label should be skipped
+        assert not graph.has_edge('"/node_a"', '"/node_b"')
+
+
+class TestDot2NetworkxNodetopicInternal:
+    """Tests for internal dot2networkx_nodetopic function"""
+
+    def test_nodetopic_publisher_subscriber(self):
+        """Test correct publisher-subscriber relationship parsing"""
+        graph_org = nx.MultiDiGraph()
+        graph_org.add_node('n1', label='"/node_a"', shape='ellipse')
+        graph_org.add_node('t1', label='"/topic_1"', shape='box')
+        graph_org.add_node('n2', label='"/node_b"', shape='ellipse')
+        graph_org.add_edge('n1', 't1')  # node_a publishes to topic_1
+        graph_org.add_edge('t1', 'n2')  # topic_1 subscribed by node_b
+
+        graph = dot2networkx_nodetopic(graph_org)
+
+        assert graph.has_node('"/node_a"')
+        assert graph.has_node('"/node_b"')
+        assert graph.has_edge('"/node_a"', '"/node_b"')
+
+    def test_nodetopic_missing_shape(self):
+        """Test handling nodes without shape attribute"""
+        graph_org = nx.MultiDiGraph()
+        graph_org.add_node('n1', label='"/node_a"')  # No shape
+        graph_org.add_node('n2', label='"/node_b"', shape='ellipse')
+        graph_org.add_edge('n1', 'n2')
+
+        graph = dot2networkx_nodetopic(graph_org)
+
+        # Edge should be skipped due to missing shape
+        assert len(graph.edges) == 0

--- a/tests/test_graph_layout.py
+++ b/tests/test_graph_layout.py
@@ -14,22 +14,283 @@
 """
 Test graph_layout module
 """
-
+import shutil
+import pytest
 import networkx as nx
-from src.dear_ros_node_viewer.graph_layout import place_node_by_group, align_layout
+from src.dear_ros_node_viewer.graph_layout import (
+    place_node_by_group,
+    place_node,
+    normalize_layout,
+    align_layout
+)
+
+# Check if graphviz is available
+GRAPHVIZ_AVAILABLE = shutil.which('dot') is not None
+SKIP_GRAPHVIZ = pytest.mark.skipif(
+    not GRAPHVIZ_AVAILABLE,
+    reason="graphviz (dot) not installed"
+)
 
 
-def test_graph_layout():
-    graph = nx.MultiDiGraph()
-    nx.add_path(graph, ['"/3"', '"/5"', '"/4"', '"/1"', '"/0"', '"/2"'])
 
-    group_setting = {
-        "__others__": {
-            "direction": "horizontal",
-            "offset": [0.0, 0.0, 1.0, 1.0],
-            "color": [16, 64, 96]
+class TestPlaceNodeByGroup:
+    """Tests for place_node_by_group function"""
+
+    @SKIP_GRAPHVIZ
+    def test_place_node_by_group_basic(self):
+        """Test basic node placement by group"""
+        graph = nx.MultiDiGraph()
+        nx.add_path(graph, ['"/3"', '"/5"', '"/4"', '"/1"', '"/0"', '"/2"'])
+
+        group_setting = {
+            "__others__": {
+                "direction": "horizontal",
+                "offset": [0.0, 0.0, 1.0, 1.0],
+                "color": [16, 64, 96]
+            }
         }
-    }
 
-    graph = place_node_by_group(graph, group_setting)
-    graph = align_layout(graph)
+        result = place_node_by_group(graph, group_setting)
+
+        # All nodes should have pos and color attributes
+        for node in result.nodes:
+            assert 'pos' in result.nodes[node]
+            assert 'color' in result.nodes[node]
+            assert len(result.nodes[node]['pos']) == 2
+            assert len(result.nodes[node]['color']) == 3
+
+    @SKIP_GRAPHVIZ
+    def test_place_node_by_group_vertical(self):
+        """Test vertical direction placement"""
+        graph = nx.MultiDiGraph()
+        graph.add_node('"/node_a"')
+        graph.add_node('"/node_b"')
+        graph.add_edge('"/node_a"', '"/node_b"')
+
+        group_setting = {
+            "__others__": {
+                "direction": "vertical",
+                "offset": [0.0, 0.0, 1.0, 1.0],
+                "color": [128, 128, 128]
+            }
+        }
+
+        result = place_node_by_group(graph, group_setting)
+
+        for node in result.nodes:
+            assert 'pos' in result.nodes[node]
+
+    @SKIP_GRAPHVIZ
+    def test_place_node_by_group_with_named_group(self):
+        """Test placement with named group matching"""
+        graph = nx.MultiDiGraph()
+        graph.add_node('"/group_a/node_1"')
+        graph.add_node('"/group_a/node_2"')
+        graph.add_node('"/group_b/node_1"')
+
+        group_setting = {
+            "group_a": {
+                "direction": "horizontal",
+                "offset": [0.0, 0.0, 0.5, 1.0],
+                "color": [255, 0, 0]
+            },
+            "group_b": {
+                "direction": "horizontal",
+                "offset": [0.5, 0.0, 0.5, 1.0],
+                "color": [0, 255, 0]
+            },
+            "__others__": {
+                "direction": "horizontal",
+                "offset": [0.0, 0.0, 1.0, 1.0],
+                "color": [128, 128, 128]
+            }
+        }
+
+        result = place_node_by_group(graph, group_setting)
+
+        # Check that nodes in group_a have the correct color
+        assert result.nodes['"/group_a/node_1"']['color'] == [255, 0, 0]
+        assert result.nodes['"/group_b/node_1"']['color'] == [0, 255, 0]
+
+    @SKIP_GRAPHVIZ
+    def test_place_node_by_group_empty_graph(self):
+        """Test placement with empty graph"""
+        graph = nx.MultiDiGraph()
+
+        group_setting = {
+            "__others__": {
+                "direction": "horizontal",
+                "offset": [0.0, 0.0, 1.0, 1.0],
+                "color": [128, 128, 128]
+            }
+        }
+
+        result = place_node_by_group(graph, group_setting)
+
+        assert len(result.nodes) == 0
+
+
+class TestPlaceNode:
+    """Tests for place_node function"""
+
+    @SKIP_GRAPHVIZ
+    def test_place_node_basic(self):
+        """Test basic node placement"""
+        graph = nx.MultiDiGraph()
+        graph.add_node('"/group/node_a"')
+        graph.add_node('"/group/node_b"')
+        graph.add_edge('"/group/node_a"', '"/group/node_b"')
+
+        layout = place_node(graph, 'group')
+
+        assert '"/group/node_a"' in layout
+        assert '"/group/node_b"' in layout
+        # Positions should be normalized to [0, 1]
+        for pos in layout.values():
+            assert 0 <= pos[0] <= 1
+            assert 0 <= pos[1] <= 1
+
+    @SKIP_GRAPHVIZ
+    def test_place_node_single_node(self):
+        """Test placement with single node"""
+        graph = nx.MultiDiGraph()
+        graph.add_node('"/group/node_a"')
+
+        layout = place_node(graph, 'group')
+
+        assert '"/group/node_a"' in layout
+
+    @SKIP_GRAPHVIZ
+    def test_place_node_no_matching_nodes(self):
+        """Test placement when no nodes match group"""
+        graph = nx.MultiDiGraph()
+        graph.add_node('"/other/node_a"')
+
+        layout = place_node(graph, 'group')
+
+        # No nodes should be in layout
+        assert len(layout) == 0
+
+
+class TestNormalizeLayout:
+    """Tests for normalize_layout function"""
+
+    def test_normalize_layout_basic(self):
+        """Test basic layout normalization"""
+        layout = {
+            'node_a': (0, 0),
+            'node_b': (100, 100),
+            'node_c': (50, 50)
+        }
+
+        result = normalize_layout(layout)
+
+        # All positions should be in [0, 1] range
+        for pos in result.values():
+            assert 0 <= pos[0] <= 1
+            assert 0 <= pos[1] <= 1
+
+        # Check specific normalized values
+        assert result['node_a'] == [0.0, 0.0]
+        assert result['node_b'] == [1.0, 1.0]
+        assert result['node_c'] == [0.5, 0.5]
+
+    def test_normalize_layout_empty(self):
+        """Test normalization of empty layout"""
+        layout = {}
+        result = normalize_layout(layout)
+        assert result == {}
+
+    def test_normalize_layout_single_node(self):
+        """Test normalization with single node"""
+        layout = {'node_a': (50, 50)}
+        result = normalize_layout(layout)
+        # Single node should be at (0, 0) after normalization
+        assert result['node_a'] == [0.0, 0.0]
+
+    def test_normalize_layout_same_position(self):
+        """Test normalization when all nodes at same position"""
+        layout = {
+            'node_a': (50, 50),
+            'node_b': (50, 50),
+        }
+        result = normalize_layout(layout)
+        # Should return without error
+        assert 'node_a' in result
+        assert 'node_b' in result
+
+    def test_normalize_layout_negative_values(self):
+        """Test normalization with negative values"""
+        layout = {
+            'node_a': (-100, -100),
+            'node_b': (100, 100),
+        }
+        result = normalize_layout(layout)
+
+        assert result['node_a'] == [0.0, 0.0]
+        assert result['node_b'] == [1.0, 1.0]
+
+
+class TestAlignLayout:
+    """Tests for align_layout function"""
+
+    def test_align_layout_basic(self):
+        """Test basic layout alignment"""
+        graph = nx.MultiDiGraph()
+        graph.add_node('"/node_a"', pos=[0.0, 0.0])
+        graph.add_node('"/node_b"', pos=[1.0, 1.0])
+
+        result = align_layout(graph)
+
+        # Center should be at (0, 0)
+        pos_a = result.nodes['"/node_a"']['pos']
+        pos_b = result.nodes['"/node_b"']['pos']
+
+        # The center of min and max should be 0
+        center_x = (pos_a[0] + pos_b[0]) / 2
+        center_y = (pos_a[1] + pos_b[1]) / 2
+        assert abs(center_x) < 0.001
+        assert abs(center_y) < 0.001
+
+    def test_align_layout_already_centered(self):
+        """Test alignment when already centered at origin"""
+        graph = nx.MultiDiGraph()
+        graph.add_node('"/node_a"', pos=[-0.5, -0.5])
+        graph.add_node('"/node_b"', pos=[0.5, 0.5])
+
+        result = align_layout(graph)
+
+        # Should remain centered
+        pos_a = result.nodes['"/node_a"']['pos']
+        pos_b = result.nodes['"/node_b"']['pos']
+        center_x = (pos_a[0] + pos_b[0]) / 2
+        center_y = (pos_a[1] + pos_b[1]) / 2
+        assert abs(center_x) < 0.001
+        assert abs(center_y) < 0.001
+
+    def test_align_layout_single_node(self):
+        """Test alignment with single node at origin"""
+        graph = nx.MultiDiGraph()
+        graph.add_node('"/node_a"', pos=[0.0, 0.0])
+
+        result = align_layout(graph)
+
+        # Single node at origin should remain unchanged
+        assert result.nodes['"/node_a"']['pos'] == [0.0, 0.0]
+
+    def test_align_layout_preserves_relative_positions(self):
+        """Test that alignment preserves relative positions"""
+        graph = nx.MultiDiGraph()
+        graph.add_node('"/node_a"', pos=[0.0, 0.0])
+        graph.add_node('"/node_b"', pos=[2.0, 0.0])
+        graph.add_node('"/node_c"', pos=[1.0, 1.0])
+
+        result = align_layout(graph)
+
+        # Check relative distances are preserved
+        pos_a = result.nodes['"/node_a"']['pos']
+        pos_b = result.nodes['"/node_b"']['pos']
+
+        # Distance between a and b should still be 2.0
+        distance = pos_b[0] - pos_a[0]
+        assert abs(distance - 2.0) < 0.001

--- a/tests/test_graph_manager.py
+++ b/tests/test_graph_manager.py
@@ -1,0 +1,323 @@
+# Copyright 2023 iwatake2222
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test graph_manager module
+"""
+import os
+import shutil
+import tempfile
+import pytest
+import networkx as nx
+
+from src.dear_ros_node_viewer.graph_manager import GraphManager
+
+# Check if graphviz is available
+GRAPHVIZ_AVAILABLE = shutil.which('dot') is not None
+SKIP_GRAPHVIZ = pytest.mark.skipif(
+    not GRAPHVIZ_AVAILABLE,
+    reason="graphviz (dot) not installed"
+)
+
+
+def get_default_app_setting():
+    """Helper to create default app settings for tests"""
+    return {
+        'display_unconnected_nodes': False,
+        'ignore_node_list': [],
+        'ignore_topic_list': [],
+    }
+
+
+def get_default_group_setting():
+    """Helper to create default group settings for tests"""
+    return {
+        "__others__": {
+            "direction": "horizontal",
+            "offset": [0.0, 0.0, 1.0, 1.0],
+            "color": [16, 64, 96]
+        }
+    }
+
+
+class TestGraphManagerInit:
+    """Tests for GraphManager initialization"""
+
+    def test_init_basic(self):
+        """Test basic GraphManager initialization"""
+        app_setting = get_default_app_setting()
+        group_setting = get_default_group_setting()
+
+        manager = GraphManager(app_setting, group_setting)
+
+        assert manager.app_setting == app_setting
+        assert manager.group_setting == group_setting
+        assert manager.dir == './'
+        assert isinstance(manager.graph, nx.MultiDiGraph)
+        assert manager.caret_path_dict == {}
+
+
+
+class TestGraphManagerLoadFromCaret:
+    """Tests for loading graphs from CARET files"""
+
+    @SKIP_GRAPHVIZ
+    def test_load_graph_from_caret_basic(self):
+        """Test loading graph from architecture.yaml"""
+        app_setting = get_default_app_setting()
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_caret('architecture.yaml')
+
+        assert len(manager.graph.nodes) > 0
+        assert manager.graph.has_node('"/node_src"')
+
+    @SKIP_GRAPHVIZ
+    def test_load_graph_from_caret_target_path(self):
+        """Test loading graph with specific target path"""
+        app_setting = get_default_app_setting()
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_caret('architecture.yaml', target_path='target_path_0')
+
+        assert len(manager.graph.nodes) > 0
+
+    @SKIP_GRAPHVIZ
+    def test_load_graph_from_caret_updates_path_dict(self):
+        """Test that caret_path_dict is updated after loading"""
+        app_setting = get_default_app_setting()
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_caret('architecture.yaml')
+
+        # Should have path information
+        assert len(manager.caret_path_dict) > 0
+
+    def test_load_graph_from_caret_file_not_found(self):
+        """Test error handling for non-existent file"""
+        app_setting = get_default_app_setting()
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        with pytest.raises(FileNotFoundError):
+            manager.load_graph_from_caret('nonexistent.yaml')
+
+
+
+class TestGraphManagerLoadFromDot:
+    """Tests for loading graphs from DOT files"""
+
+    @SKIP_GRAPHVIZ
+    def test_load_graph_from_dot_nodeonly(self):
+        """Test loading graph from node-only DOT file"""
+        app_setting = get_default_app_setting()
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_dot('./sample/rosgraph_nodeonly.dot')
+
+        assert len(manager.graph.nodes) > 0
+        assert manager.graph.has_node('"/node_src"')
+
+    @SKIP_GRAPHVIZ
+    def test_load_graph_from_dot_nodetopic(self):
+        """Test loading graph from node-topic DOT file"""
+        app_setting = get_default_app_setting()
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_dot('./sample/rosgraph_nodetopic.dot')
+
+        assert len(manager.graph.nodes) > 0
+
+    @SKIP_GRAPHVIZ
+    def test_load_graph_from_dot_updates_dir(self):
+        """Test that directory is updated after loading"""
+        app_setting = get_default_app_setting()
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_dot('./sample/rosgraph_nodeonly.dot')
+
+        assert manager.dir == './sample/'
+
+
+
+class TestGraphManagerFilterNode:
+    """Tests for node filtering"""
+
+    @SKIP_GRAPHVIZ
+    def test_filter_node_basic(self):
+        """Test basic node filtering"""
+        app_setting = get_default_app_setting()
+        app_setting['ignore_node_list'] = ['/node_src']
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_dot('./sample/rosgraph_nodeonly.dot')
+
+        # /node_src should be filtered out
+        assert not manager.graph.has_node('"/node_src"')
+
+    @SKIP_GRAPHVIZ
+    def test_filter_node_regex(self):
+        """Test node filtering with regex pattern"""
+        app_setting = get_default_app_setting()
+        app_setting['ignore_node_list'] = ['/node_src.*']
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_dot('./sample/rosgraph_nodeonly.dot')
+
+        # All nodes matching /node_src.* should be filtered out
+        for node in manager.graph.nodes:
+            assert not node.strip('"').startswith('/node_src')
+
+    @SKIP_GRAPHVIZ
+    def test_filter_node_empty_list(self):
+        """Test that empty filter list doesn't remove nodes"""
+        app_setting = get_default_app_setting()
+        app_setting['ignore_node_list'] = []
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_dot('./sample/rosgraph_nodeonly.dot')
+
+        assert len(manager.graph.nodes) > 0
+
+
+
+class TestGraphManagerFilterTopic:
+    """Tests for topic filtering"""
+
+    @SKIP_GRAPHVIZ
+    def test_filter_topic_basic(self):
+        """Test basic topic filtering"""
+        app_setting = get_default_app_setting()
+        app_setting['ignore_topic_list'] = ['/topic_src']
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_dot('./sample/rosgraph_nodeonly.dot')
+
+        # Edges with /topic_src should be filtered out
+        for edge in manager.graph.edges:
+            edge_data = manager.graph.edges[edge]
+            if 'label' in edge_data:
+                assert edge_data['label'].strip('"') != '/topic_src'
+
+    @SKIP_GRAPHVIZ
+    def test_filter_topic_regex(self):
+        """Test topic filtering with regex pattern"""
+        app_setting = get_default_app_setting()
+        app_setting['ignore_topic_list'] = ['/topic_src.*']
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_dot('./sample/rosgraph_nodeonly.dot')
+
+        # Edges with topics matching /topic_src.* should be filtered out
+        for edge in manager.graph.edges:
+            edge_data = manager.graph.edges[edge]
+            if 'label' in edge_data:
+                label = edge_data['label'].strip('"')
+                assert not label.startswith('/topic_src')
+
+
+
+class TestGraphManagerClearCaretPathDict:
+    """Tests for clear_caret_path_dict method"""
+
+    @SKIP_GRAPHVIZ
+    def test_clear_caret_path_dict(self):
+        """Test clearing CARET path dictionary"""
+        app_setting = get_default_app_setting()
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        # Load to populate path dict
+        manager.load_graph_from_caret('architecture.yaml')
+        initial_count = len(manager.caret_path_dict)
+        assert initial_count > 0
+
+        # Clear and reload
+        manager.clear_caret_path_dict()
+
+        # Should have only the << CLEAR >> entry
+        assert '<< CLEAR >>' in manager.caret_path_dict
+
+
+
+class TestGraphManagerPostprocess:
+    """Tests for load_graph_postprocess method"""
+
+    @SKIP_GRAPHVIZ
+    def test_postprocess_sets_node_positions(self):
+        """Test that postprocess sets node positions"""
+        app_setting = get_default_app_setting()
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_dot('./sample/rosgraph_nodeonly.dot')
+
+        # All nodes should have pos attribute
+        for node in manager.graph.nodes:
+            assert 'pos' in manager.graph.nodes[node]
+
+    @SKIP_GRAPHVIZ
+    def test_postprocess_sets_node_colors(self):
+        """Test that postprocess sets node colors"""
+        app_setting = get_default_app_setting()
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_dot('./sample/rosgraph_nodeonly.dot')
+
+        # All nodes should have color attribute
+        for node in manager.graph.nodes:
+            assert 'color' in manager.graph.nodes[node]
+
+
+
+class TestGraphManagerDisplayUnconnectedNodes:
+    """Tests for display_unconnected_nodes option"""
+
+    @SKIP_GRAPHVIZ
+    def test_display_unconnected_true(self):
+        """Test with display_unconnected_nodes=True"""
+        app_setting = get_default_app_setting()
+        app_setting['display_unconnected_nodes'] = True
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_caret('architecture.yaml')
+
+        # Should have nodes even if they're unconnected
+        assert len(manager.graph.nodes) > 0
+
+    @SKIP_GRAPHVIZ
+    def test_display_unconnected_false(self):
+        """Test with display_unconnected_nodes=False"""
+        app_setting = get_default_app_setting()
+        app_setting['display_unconnected_nodes'] = False
+        group_setting = get_default_group_setting()
+        manager = GraphManager(app_setting, group_setting)
+
+        manager.load_graph_from_caret('architecture.yaml')
+
+        # Isolated nodes should be removed
+        isolated_nodes = list(nx.isolates(manager.graph))
+        assert len(isolated_nodes) == 0

--- a/tests/test_logger_factory.py
+++ b/tests/test_logger_factory.py
@@ -1,0 +1,186 @@
+# Copyright 2023 iwatake2222
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test logger_factory module
+"""
+import os
+import logging
+import tempfile
+
+from src.dear_ros_node_viewer.logger_factory import LoggerFactory
+
+
+class TestLoggerFactoryCreate:
+    """Tests for LoggerFactory.create method"""
+
+    def test_create_basic(self):
+        """Test basic logger creation"""
+        logger = LoggerFactory.create('test_logger')
+
+        assert logger is not None
+        assert isinstance(logger, logging.Logger)
+        assert logger.name == 'test_logger'
+
+    def test_create_multiple_loggers(self):
+        """Test creating multiple loggers with different names"""
+        logger1 = LoggerFactory.create('test_logger_1')
+        logger2 = LoggerFactory.create('test_logger_2')
+
+        assert logger1.name == 'test_logger_1'
+        assert logger2.name == 'test_logger_2'
+        assert logger1 is not logger2
+
+    def test_create_same_name_returns_same_logger(self):
+        """Test that creating logger with same name returns same instance"""
+        logger1 = LoggerFactory.create('same_name_logger')
+        logger2 = LoggerFactory.create('same_name_logger')
+
+        # logging.getLogger returns same instance for same name
+        assert logger1 is logger2
+
+    def test_create_logger_has_handlers(self):
+        """Test that created logger has handlers attached"""
+        logger = LoggerFactory.create('test_handler_logger')
+
+        assert len(logger.handlers) > 0
+
+    def test_create_logger_level(self):
+        """Test that logger has correct level set"""
+        original_level = LoggerFactory.level
+        LoggerFactory.level = logging.WARNING
+
+        logger = LoggerFactory.create('test_level_logger')
+
+        assert logger.level == logging.WARNING
+
+        # Restore original level
+        LoggerFactory.level = original_level
+
+
+class TestLoggerFactoryConfig:
+    """Tests for LoggerFactory.config method"""
+
+    def test_config_level(self):
+        """Test configuring log level"""
+        original_level = LoggerFactory.level
+        original_filename = LoggerFactory.log_filename
+
+        LoggerFactory.config(logging.ERROR, None)
+
+        assert LoggerFactory.level == logging.ERROR
+
+        # Restore original settings
+        LoggerFactory.level = original_level
+        LoggerFactory.log_filename = original_filename
+
+    def test_config_filename(self):
+        """Test configuring log filename"""
+        original_level = LoggerFactory.level
+        original_filename = LoggerFactory.log_filename
+
+        LoggerFactory.config(logging.DEBUG, 'test.log')
+
+        assert LoggerFactory.log_filename == 'test.log'
+
+        # Restore original settings
+        LoggerFactory.level = original_level
+        LoggerFactory.log_filename = original_filename
+
+    def test_config_with_file_handler(self):
+        """Test that file handler is added when filename is configured"""
+        original_level = LoggerFactory.level
+        original_filename = LoggerFactory.log_filename
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.log', delete=False) as f:
+            temp_log_path = f.name
+
+        try:
+            LoggerFactory.config(logging.DEBUG, temp_log_path)
+            logger = LoggerFactory.create('test_file_handler_logger')
+
+            # Logger should have file handler
+            has_file_handler = any(
+                isinstance(h, logging.FileHandler) for h in logger.handlers
+            )
+            assert has_file_handler
+
+            # Test that logging works
+            logger.info('Test message')
+
+        finally:
+            # Restore original settings
+            LoggerFactory.level = original_level
+            LoggerFactory.log_filename = original_filename
+            if os.path.exists(temp_log_path):
+                os.unlink(temp_log_path)
+
+
+class TestLoggerFactoryLogging:
+    """Tests for actual logging functionality"""
+
+    def test_logger_can_log_debug(self):
+        """Test that logger can log debug messages"""
+        original_level = LoggerFactory.level
+        LoggerFactory.level = logging.DEBUG
+
+        logger = LoggerFactory.create('test_debug_logger')
+
+        # Should not raise exception
+        logger.debug('Debug message')
+
+        LoggerFactory.level = original_level
+
+    def test_logger_can_log_info(self):
+        """Test that logger can log info messages"""
+        logger = LoggerFactory.create('test_info_logger')
+
+        # Should not raise exception
+        logger.info('Info message')
+
+    def test_logger_can_log_warning(self):
+        """Test that logger can log warning messages"""
+        logger = LoggerFactory.create('test_warning_logger')
+
+        # Should not raise exception
+        logger.warning('Warning message')
+
+    def test_logger_can_log_error(self):
+        """Test that logger can log error messages"""
+        logger = LoggerFactory.create('test_error_logger')
+
+        # Should not raise exception
+        logger.error('Error message')
+
+    def test_logger_format(self):
+        """Test that logger uses correct format"""
+        logger = LoggerFactory.create('test_format_logger')
+
+        # Check that stream handler has formatter
+        for handler in logger.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                assert handler.formatter is not None
+
+
+class TestLoggerFactoryClassAttributes:
+    """Tests for LoggerFactory class attributes"""
+
+    def test_default_level(self):
+        """Test default log level"""
+        # Default level should be DEBUG
+        assert LoggerFactory.level == logging.DEBUG
+
+    def test_default_filename(self):
+        """Test default log filename"""
+        # Default filename should be None
+        assert LoggerFactory.log_filename is None


### PR DESCRIPTION
## Summary
- Add comprehensive test coverage for core modules (caret2networkx, dot2networkx, graph_layout, graph_manager, logger_factory, caret_extend_callback_group, caret_extend_path)
- Add CLAUDE.md for Claude Code guidance
- Update README.md with development setup and test instructions
- Add flake8 exclude config for .venv

## Test plan
- [x] Run `pytest tests/ -v` - all tests pass (91 passed, 23 skipped)
- [x] Tests requiring graphviz are properly skipped when not installed
- [x] Verify flake8 excludes .venv directory

🤖 Generated with [Claude Code](https://claude.ai/claude-code)