### PR TITLE
fix: apply try-finally

### DIFF
--- a/src/dear_ros_node_viewer/graph_manager.py
+++ b/src/dear_ros_node_viewer/graph_manager.py
@@ -55,8 +55,10 @@ class GraphManager:
   def load_graph_from_running_ros(self):
     """ load_graph_from_running_ros """
     ros2networkx = Ros2Networkx(node_name='temp')
-    ros2networkx.save_graph('./temp.dot')
-    ros2networkx.shutdown()
+    try:
+      ros2networkx.save_graph('./temp.dot')
+    finally:
+      ros2networkx.shutdown()
     self.load_graph_from_dot('./temp.dot')
     # for node in self.graph.nodes:
     #     if '"/temp"' == node:


### PR DESCRIPTION
## Summary

If an exception occurs during `save_graph` execution in `load_graph_from_running_ros`, the process fails to reach `shutdown()`, leaving the node undestroyed.
Attempting to reinitialize while the undestroyed node remains causes errors such as duplicate ROS 2 nodes.
Enclosed save_graph in a try block and `shutdown()` in a finally block to ensure `shutdown()` is always called even when an exception occurs.